### PR TITLE
Optimize Rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "test_rust"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "either"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "regex"
@@ -50,5 +101,6 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 name = "test_rust"
 version = "0.1.0"
 dependencies = [
+ "rayon",
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "test_rust"
 edition = "2021"
+version = "0.1.0"
 
 [[bin]]
 name = "test_rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ name = "test_rust"
 path = "test_rust.rs"
 
 [dependencies]
+rayon = "1.10.0"
 regex = "1.5.4"

--- a/test_rust.rs
+++ b/test_rust.rs
@@ -5,7 +5,6 @@ use std::fs;
 
 fn main() {
     let text = fs::read_to_string("posts.txt").unwrap();
-    let lines: Vec<&str> = text.lines().collect();
 
     let regexps = vec![
         Regex::new(r"(?i)linux").unwrap(),
@@ -36,8 +35,8 @@ fn main() {
     let mut total_matches = 0;
 
     for _ in 0..iterations {
-        total_matches = lines
-            .par_iter()
+        total_matches = text
+            .par_lines()
             .map(|line| regexps.iter().filter(|r| r.is_match(line)).count())
             .sum();
     }

--- a/test_rust.rs
+++ b/test_rust.rs
@@ -33,8 +33,11 @@ fn main() {
         Regex::new(r"\b[Xx]org\b").unwrap(),
     ];
 
-    let args: Vec<String> = env::args().collect();
-    let iterations: usize = args[1].parse().expect("Invalid number of iterations");
+    let iterations: usize = env::args()
+        .nth(1)
+        .unwrap()
+        .parse()
+        .expect("Invalid number of iterations");
 
     let mut total_matches = 0;
 

--- a/test_rust.rs
+++ b/test_rust.rs
@@ -42,11 +42,10 @@ fn main() {
         for r in &regexps {
             for line in &lines {
                 match r.find(line) {
-                  Some(_value) => {
-                    total_matches += 1;                    
-                  },
-                  None => {
-                  }
+                    Some(_value) => {
+                        total_matches += 1;
+                    }
+                    None => {}
                 }
             }
         }

--- a/test_rust.rs
+++ b/test_rust.rs
@@ -1,16 +1,10 @@
+use rayon::prelude::*;
 use regex::Regex;
 use std::env;
 use std::fs;
 
 fn main() {
-    let text = match fs::read_to_string("posts.txt") {
-        Ok(content) => content,
-        Err(_) => {
-            eprintln!("Error reading text file.");
-            return;
-        }
-    };
-
+    let text = fs::read_to_string("posts.txt").unwrap();
     let lines: Vec<&str> = text.lines().collect();
 
     let regexps = vec![
@@ -42,17 +36,11 @@ fn main() {
     let mut total_matches = 0;
 
     for _ in 0..iterations {
-        for r in &regexps {
-            for line in &lines {
-                match r.find(line) {
-                    Some(_value) => {
-                        total_matches += 1;
-                    }
-                    None => {}
-                }
-            }
-        }
+        total_matches = lines
+            .par_iter()
+            .map(|line| regexps.iter().filter(|r| r.is_match(line)).count())
+            .sum();
     }
 
-    println!("Total matches: {}", total_matches / iterations);
+    println!("Total matches: {total_matches}");
 }

--- a/test_rust.rs
+++ b/test_rust.rs
@@ -1,37 +1,33 @@
 use rayon::prelude::*;
 use regex::Regex;
 use std::env;
+use std::error::Error;
 use std::fs;
 
-fn main() {
-    let text = fs::read_to_string("posts.txt").unwrap();
+fn main() -> Result<(), Box<dyn Error>> {
+    let text = fs::read_to_string("posts.txt")?;
 
     let regexps = vec![
-        Regex::new(r"(?i)linux").unwrap(),
-        Regex::new(r"(?i)debian").unwrap(),
-        Regex::new(r"(?i)ubuntu").unwrap(),
-        Regex::new(r#"\bredhat\b"#).unwrap(),
-        Regex::new(r"\bRHEL\b").unwrap(),
-        Regex::new(r"\bSUSE\b").unwrap(),
-        Regex::new(r"\bCentOS\b").unwrap(),
-        Regex::new(r"(?i)\bopensuse\b").unwrap(),
-        Regex::new(r"(?i)\bslackware\b").unwrap(),
-        Regex::new(r"\bKDE\b").unwrap(),
-        Regex::new(r"\bGTK\d?\b").unwrap(),
-        Regex::new(r"#GNOME\b").unwrap(),
-        Regex::new(r"\bGNOME\s?\d+").unwrap(),
-        Regex::new(r"(?i)\bkde plasma\b").unwrap(),
-        Regex::new(r"apt-get").unwrap(),
-        Regex::new(r"(?i)\bflatpak\b").unwrap(),
-        Regex::new(r"\b[Xx]org\b").unwrap(),
+        Regex::new(r"(?i)linux")?,
+        Regex::new(r"(?i)debian")?,
+        Regex::new(r"(?i)ubuntu")?,
+        Regex::new(r#"\bredhat\b"#)?,
+        Regex::new(r"\bRHEL\b")?,
+        Regex::new(r"\bSUSE\b")?,
+        Regex::new(r"\bCentOS\b")?,
+        Regex::new(r"(?i)\bopensuse\b")?,
+        Regex::new(r"(?i)\bslackware\b")?,
+        Regex::new(r"\bKDE\b")?,
+        Regex::new(r"\bGTK\d?\b")?,
+        Regex::new(r"#GNOME\b")?,
+        Regex::new(r"\bGNOME\s?\d+")?,
+        Regex::new(r"(?i)\bkde plasma\b")?,
+        Regex::new(r"apt-get")?,
+        Regex::new(r"(?i)\bflatpak\b")?,
+        Regex::new(r"\b[Xx]org\b")?,
     ];
 
-    let iterations: usize = env::args()
-        .nth(1)
-        .unwrap()
-        .parse()
-        .expect("Invalid number of iterations");
-
+    let iterations: usize = env::args().nth(1).unwrap_or("1".to_string()).parse()?;
     let mut total_matches = 0;
 
     for _ in 0..iterations {
@@ -42,4 +38,6 @@ fn main() {
     }
 
     println!("Total matches: {total_matches}");
+
+    Ok(())
 }


### PR DESCRIPTION
This patch makes the Rust version utilize all available CPU cores automatically.

On my 4-core (8 thread) Linux VM it runs 2.2x faster then the previous version. In theory, the more cores you have the faster it should be, but we'll see how it fares on those VMs you have there.

[![asciicast](https://asciinema.org/a/ZWh1oqoCfsluCh5RDLtgoEgEa.svg)](https://asciinema.org/a/ZWh1oqoCfsluCh5RDLtgoEgEa?autoplay=1)

Note that I benchmarked on a bigger file - 1 million lines - which I created by concatenating the original posts.txt thousands of times (in bash: `for i in {1..10000}; do cat posts.txt >> posts-big.txt; done`), and using just a single iteration.

I believe that benchmarking on a small file (like the original posts.txt with 30 lines) is not the best idea because any implementation that would benefit from parallelization (like this one) won't be able to show its full potential due to thread synchronization overhead and boot time dominating the runtime.

Btw, this is pretty nifty tool for benchmarking: https://github.com/sharkdp/hyperfine